### PR TITLE
Convert readme to index html

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,5 @@
-![Bo](assets/rubber-bo.jpeg)
-# Welcome to bomartin.org
+# Bo's Github Pages Site
 
-This is the personal web site of Bo Martin. It's just a static site using Github pages. You can't really do anything here but learn a little about Bo.
+This is a simple static web site because Github makes it so easy and free.
 
-## About Bo
-I live in East Tennessee. It's not that great. You wouldn't be interested. Kidding.
-
-Professionally, I'm a software engineer and engineering manager. Learn more about me professionally [here on LinkedIn](https://www.linkedin.com/in/bo-martin/). I feel like I've done just about every job in computing. My current role is Director of Software Engineering at [Lirio](https://lirio.com/).
-
-Personally, I'm a husband, uncle, brother, son and doggie daddy. I like playing and practicing golf. I like traveling with my lovely wife, Mary Eva. I love good live music.
-
-## Here's Teddy
-
-He's a Carolina Dog. He has some special ways including getting on top of stuff.
-
-![Teddy on a rock](assets/teddy-on-a-rock.jpeg)
+Simplest possible page for now. More coming soon.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="UTF-8">
+        <title>Welcome to bomartin&period;org</title>
+        <style>
+/* From extension vscode.github */
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.vscode-dark img[src$=\#gh-light-mode-only],
+.vscode-light img[src$=\#gh-dark-mode-only] {
+	display: none;
+}
+
+</style>
+        
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/Microsoft/vscode/extensions/markdown-language-features/media/markdown.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/Microsoft/vscode/extensions/markdown-language-features/media/highlight.css">
+<style>
+            body {
+                font-family: -apple-system, BlinkMacSystemFont, 'Segoe WPC', 'Segoe UI', system-ui, 'Ubuntu', 'Droid Sans', sans-serif;
+                font-size: 14px;
+                line-height: 1.6;
+            }
+        </style>
+        <style>
+.task-list-item {
+    list-style-type: none;
+}
+
+.task-list-item-checkbox {
+    margin-left: -20px;
+    vertical-align: middle;
+    pointer-events: none;
+}
+</style>
+        
+    </head>
+    <body class="vscode-body vscode-light">
+        <p><img src="file:////Users/bo/source/bomartin.org/martinbo66.github.io/assets/rubber-bo.jpeg" alt="Bo"></p>
+<h1 id="welcome-to-bomartinorg">Welcome to <a href="http://bomartin.org">bomartin.org</a></h1>
+<p>This is the personal web site of Bo Martin. It's just a static site using Github pages. You can't really do anything here but learn a little about Bo.</p>
+<h2 id="about-bo">About Bo</h2>
+<p>I live in East Tennessee. It's not that great. You wouldn't be interested. Kidding.</p>
+<p>Professionally, I'm a software engineer and engineering manager. Learn more about me professionally <a href="https://www.linkedin.com/in/bo-martin/">here on LinkedIn</a>. My current role is Director of Software Engineering at <a href="https://lirio.com/">Lirio</a>.</p>
+<p>Personally, I'm a husband, uncle, brother, son and doggie daddy. I like playing and practicing golf. I enjoy traveling with my lovely wife, Mary Eva. I love good live music.</p>
+<h2 id="heres-teddy">Here's Teddy</h2>
+<p>He's a Carolina Dog mix. He has some special ways including getting on top of stuff.</p>
+<p><img src="file:////Users/bo/source/bomartin.org/martinbo66.github.io/assets/teddy-on-a-rock.jpeg" alt="Teddy on a rock"></p>
+
+        
+        
+    </body>
+    </html>

--- a/index.html
+++ b/index.html
@@ -1,57 +1,85 @@
 <!DOCTYPE html>
-    <html>
-    <head>
-        <meta charset="UTF-8">
-        <title>Welcome to bomartin&period;org</title>
-        <style>
-/* From extension vscode.github */
-/*---------------------------------------------------------------------------------------------
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Welcome to bomartin&period;org</title>
+    <style>
+      /* From extension vscode.github */
+      /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.vscode-dark img[src$=\#gh-light-mode-only],
-.vscode-light img[src$=\#gh-dark-mode-only] {
-	display: none;
-}
+      .vscode-dark img[src$='\#gh-light-mode-only'],
+      .vscode-light img[src$='\#gh-dark-mode-only'] {
+        display: none;
+      }
+    </style>
 
-</style>
-        
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/Microsoft/vscode/extensions/markdown-language-features/media/markdown.css">
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/Microsoft/vscode/extensions/markdown-language-features/media/highlight.css">
-<style>
-            body {
-                font-family: -apple-system, BlinkMacSystemFont, 'Segoe WPC', 'Segoe UI', system-ui, 'Ubuntu', 'Droid Sans', sans-serif;
-                font-size: 14px;
-                line-height: 1.6;
-            }
-        </style>
-        <style>
-.task-list-item {
-    list-style-type: none;
-}
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/gh/Microsoft/vscode/extensions/markdown-language-features/media/markdown.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/gh/Microsoft/vscode/extensions/markdown-language-features/media/highlight.css"
+    />
+    <style>
+      body {
+        font-family: sans-serif; /* 1 */
+        -ms-text-size-adjust: 100%; /* 2 */
+        -webkit-text-size-adjust: 100%; /* 2 */
+      }
+    </style>
+    <style>
+      .task-list-item {
+        list-style-type: none;
+      }
 
-.task-list-item-checkbox {
-    margin-left: -20px;
-    vertical-align: middle;
-    pointer-events: none;
-}
-</style>
-        
-    </head>
-    <body class="vscode-body vscode-light">
-        <p><img src="file:////Users/bo/source/bomartin.org/martinbo66.github.io/assets/rubber-bo.jpeg" alt="Bo"></p>
-<h1 id="welcome-to-bomartinorg">Welcome to <a href="http://bomartin.org">bomartin.org</a></h1>
-<p>This is the personal web site of Bo Martin. It's just a static site using Github pages. You can't really do anything here but learn a little about Bo.</p>
-<h2 id="about-bo">About Bo</h2>
-<p>I live in East Tennessee. It's not that great. You wouldn't be interested. Kidding.</p>
-<p>Professionally, I'm a software engineer and engineering manager. Learn more about me professionally <a href="https://www.linkedin.com/in/bo-martin/">here on LinkedIn</a>. My current role is Director of Software Engineering at <a href="https://lirio.com/">Lirio</a>.</p>
-<p>Personally, I'm a husband, uncle, brother, son and doggie daddy. I like playing and practicing golf. I enjoy traveling with my lovely wife, Mary Eva. I love good live music.</p>
-<h2 id="heres-teddy">Here's Teddy</h2>
-<p>He's a Carolina Dog mix. He has some special ways including getting on top of stuff.</p>
-<p><img src="file:////Users/bo/source/bomartin.org/martinbo66.github.io/assets/teddy-on-a-rock.jpeg" alt="Teddy on a rock"></p>
+      .task-list-item-checkbox {
+        margin-left: -20px;
+        vertical-align: middle;
+        pointer-events: none;
+      }
+    </style>
+  </head>
+  <body class="vscode-body vscode-light">
+    <h1 id="welcome-to-bomartinorg">
+        Welcome to <a href="http://bomartin.org">bomartin.org</a>
+      </h1>
+    <p>
+      <img width="70%" height="300" src="assets/rubber-bo.jpeg" alt="Bo" />
+    </p>
 
-        
-        
-    </body>
-    </html>
+    <p>
+      This is the personal web site of Bo Martin. It's just a static site using
+      Github pages. You can't really do anything here but learn a little about
+      Bo.
+    </p>
+    <h2 id="about-bo">About Bo</h2>
+    <p>
+      I live in East Tennessee. It's not that great. You wouldn't be interested.
+      Kidding.
+    </p>
+    <p>
+      Professionally, I'm a software engineer and engineering manager. Learn
+      more about me professionally
+      <a href="https://www.linkedin.com/in/bo-martin/">here on LinkedIn</a>. My
+      current role is Director of Software Engineering at
+      <a href="https://lirio.com/">Lirio</a>.
+    </p>
+    <p>
+      Personally, I'm a husband, uncle, brother, son and doggie daddy. I like
+      playing and practicing golf. I enjoy traveling with my lovely wife, Mary
+      Eva. I love good live music.
+    </p>
+    <h2 id="heres-teddy">Here's Teddy</h2>
+    <p>
+      He's a Carolina Dog mix. He has some special ways including getting on top
+      of stuff.
+    </p>
+    <p>
+      <img src="assets/teddy-on-a-rock.jpeg" alt="Teddy on a rock" />
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
The site was working but we didn't have an index.html. Moved the content from the readme to that file with some basic styling applied by a VSCode extension called Markdown All In One. It's pulling style sheets from an Azure CDN I think. Will replace with local stylized site soon. Good enough for now.